### PR TITLE
Multiple fingerprints allowed on same device

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,7 +7,7 @@
 
     <application
         android:name=".ApplicationClass"
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"

--- a/app/src/main/java/com/sawolabs/androidsdk/CryptographyManager.kt
+++ b/app/src/main/java/com/sawolabs/androidsdk/CryptographyManager.kt
@@ -126,6 +126,7 @@ private class CryptographyManagerImpl : CryptographyManager {
             setEncryptionPaddings(ENCRYPTION_PADDING)
             setKeySize(KEY_SIZE)
             setUserAuthenticationRequired(true)
+            setInvalidatedByBiometricEnrollment(false)
         }
 
         val keyGenParams = paramsBuilder.build()


### PR DESCRIPTION
Allows user to begin sign in process with any of the registered fingerprints. Furthermore we don't require the same fingerprint for both encryption and decryption.